### PR TITLE
Set proper module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module bitwarden_to_keepassxc
+module github.com/thelazyoxymoron/bitwarden-to-keepassxc-converter
 
 go 1.20


### PR DESCRIPTION
Adding the full name of the package allows for end-users to install the binary with:

    go install github.com/thelazyoxymoron/bitwarden-to-keepassxc-converter@latest