### PR TITLE
Update readme to reflect KeePassXC import current status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Bitwarden to KeepassXC Converter
-KeepassXC doesn't have a native import feature from Bitwarden ([yet](https://github.com/keepassxreboot/keepassxc/issues/8367)). This is a simple script which converts a bitwarden export to a csv format which can be imported in KeepassXC.<br>
+KeepassXC does have a native import feature from Bitwarden starting with [version 2.7.7](https://github.com/keepassxreboot/keepassxc/releases/tag/2.7.7) but it does not ([yet support organization exports](https://github.com/keepassxreboot/keepassxc/pull/10499)) correctly. This is a simple script which converts a bitwarden export to a csv format which can be imported in KeepassXC.<br>
 
 It supports exporting your normal website logins including TOTP, secure notes and credit/debit cards. Since there are no username/password fields for credit/debit card type, the script adds a new group called "Cards" and imports all the card details in "notes" field.
 


### PR DESCRIPTION
KeePass now supports Bitwarden json imports (unencrypted and encrypted) but it does not yet work for organization exports.